### PR TITLE
Update error.sh to ignore scp errors

### DIFF
--- a/android/error.sh
+++ b/android/error.sh
@@ -4,6 +4,6 @@ set -eu
 echo "--- Uploading logs on error"
 echo "failures/${DEVICE}/${BUILD_UUID}/"
 ssh jenkins@blob.lineageos.org mkdir -p /home/jenkins/incoming/failures/${DEVICE}/${BUILD_UUID}/
-scp /tmp/android-reset.log jenkins@blob.lineageos.org:/home/jenkins/incoming/failures/${DEVICE}/${BUILD_UUID}/
-scp /tmp/android-sync.log jenkins@blob.lineageos.org:/home/jenkins/incoming/failures/${DEVICE}/${BUILD_UUID}/
-scp /tmp/android-build.log jenkins@blob.lineageos.org:/home/jenkins/incoming/failures/${DEVICE}/${BUILD_UUID}/
+scp /tmp/android-reset.log jenkins@blob.lineageos.org:/home/jenkins/incoming/failures/${DEVICE}/${BUILD_UUID}/ || true
+scp /tmp/android-sync.log jenkins@blob.lineageos.org:/home/jenkins/incoming/failures/${DEVICE}/${BUILD_UUID}/ || true
+scp /tmp/android-build.log jenkins@blob.lineageos.org:/home/jenkins/incoming/failures/${DEVICE}/${BUILD_UUID}/ || true


### PR DESCRIPTION
Hi,

Because android-reset.log or android-sync.log is not generated every time (depending on which step it is blocking)
I suggest uploading android-build.log first to at least get the build logs

Thanks.

Signed-off-by: Frederic Lesur <contact@memiks.fr>