### PR TITLE
Output both build stdout and stderr to file

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -65,7 +65,7 @@ if [ "$RELEASE_TYPE" '==' "experimental" ]; then
 fi
 echo "--- Building"
 export OVERRIDE_TARGET_FLATTEN_APEX=true 
-mka otatools-package target-files-package dist > /tmp/android-build.log
+mka otatools-package target-files-package dist > /tmp/android-build.log 2>&1
 
 echo "--- Uploading"
 ssh jenkins@blob.lineageos.org mkdir -p /home/jenkins/incoming/${DEVICE}/${BUILD_UUID}/


### PR DESCRIPTION
The build output may be directed to stderr pipe, which is not logged to the android-build.log